### PR TITLE
Remove unused estimation fields from schema

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,7 +72,6 @@ Feature descriptions belonging to epics:
 - `acceptanceCriteria` (text)
 - `status` (enum: draft, ready, in_progress, review, completed)
 - `priority` (enum: low, medium, high, critical)
-- `storyPoints` (integer)
 - `orderIndex` (integer)
 - Timestamps: `createdAt`, `updatedAt`
 
@@ -83,8 +82,6 @@ Granular work items belonging to stories:
 - `title` (text, required)
 - `description` (text)
 - `status` (enum: todo, in_progress, blocked, completed)
-- `estimatedHours` (decimal)
-- `actualHours` (decimal)
 - `orderIndex` (integer)
 - Timestamps: `createdAt`, `updatedAt`, `completedAt`
 
@@ -178,8 +175,7 @@ DATABASE_URL=postgresql://user:password@host:port/database
 1. Always create Repositories first (via UI only)
 2. Always create Epics before Stories (must specify repoId)
 3. Always create Stories before Tasks
-3. Use appropriate status transitions (e.g., draft → ready → in_progress → review → completed)
-4. Set realistic story points and time estimates
+4. Use appropriate status transitions (e.g., draft → ready → in_progress → review → completed)
 5. Use descriptive titles and acceptance criteria
 
 ### Database Operations

--- a/README.md
+++ b/README.md
@@ -1,36 +1,126 @@
-This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
+# Spec-This
+
+A specification-driven development tool that combines a Next.js web application with an MCP (Model Context Protocol) server. Manage software development through a hierarchical structure of Epics → Stories → Tasks.
+
+## Prerequisites
+
+- Node.js 18+
+- PostgreSQL database
+- npm or yarn
 
 ## Getting Started
 
-First, run the development server:
+### 1. Install Dependencies
 
 ```bash
-npm run dev
-# or
-yarn dev
-# or
-pnpm dev
-# or
-bun dev
+npm install
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+### 2. Set Up Environment Variables
 
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
+Create a `.env.local` file in the root directory:
 
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
+```bash
+DATABASE_URL=postgresql://user:password@host:port/database
+```
 
-## Learn More
+### 3. Set Up the Database
 
-To learn more about Next.js, take a look at the following resources:
+Generate and apply the database schema:
 
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
+```bash
+# Generate migration files
+npm run db:generate
 
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
+# Apply migrations to database
+npm run db:migrate
 
-## Deploy on Vercel
+# Or use push for development (faster, skips migration files)
+npm run db:push
+```
 
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
+### 4. Run the Application
 
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+**Next.js Web App:**
+
+```bash
+npm run dev          # Development server (http://localhost:3000)
+npm run build        # Production build
+npm run start        # Start production server
+```
+
+**MCP Server:**
+
+```bash
+npm run dev:mcp      # Development with auto-reload
+npm run build:mcp    # Compile to dist/mcp-server.js
+npm run start:mcp    # Run compiled server
+```
+
+## Database Management
+
+### Common Commands
+
+```bash
+npm run db:generate  # Generate new migration files from schema changes
+npm run db:migrate   # Apply pending migrations
+npm run db:push      # Push schema changes directly (dev mode)
+npm run db:studio    # Open Drizzle Studio UI for database inspection
+```
+
+### Making Schema Changes
+
+1. Edit `lib/db/schema.ts`
+2. Run `npm run db:generate` to create migration files
+3. Review the generated migration in `drizzle/` directory
+4. Run `npm run db:migrate` to apply changes
+
+> **Tip:** Use `npm run db:push` during development for faster iteration without generating migration files.
+
+## Project Structure
+
+```
+spec-this/
+├── app/                    # Next.js app directory (UI)
+│   ├── components/        # React components
+│   ├── epics/[id]/        # Epic detail pages
+│   ├── stories/[id]/      # Story detail pages
+│   └── api/               # API routes
+├── lib/
+│   ├── db/
+│   │   ├── schema.ts      # Drizzle database schema
+│   │   └── index.ts       # Database connection
+│   └── mcp/
+│       └── tools/         # MCP tool implementations
+├── mcp-server.ts          # MCP server entry point
+├── drizzle/               # Database migrations
+└── drizzle.config.ts      # Drizzle ORM configuration
+```
+
+## MCP Tools
+
+The MCP server exposes tools for managing specifications:
+
+- `read_repos` - Fetch repositories
+- `read_epics` - Fetch epics with filtering
+- `upsert_epic` - Create/update epics
+- `read_stories` - Fetch stories with filtering
+- `upsert_story` - Create/update stories
+- `read_tasks` - Fetch tasks with filtering
+- `upsert_task` - Create/update tasks
+
+## Documentation
+
+For detailed architecture, best practices, and development guidelines, see [CLAUDE.md](./CLAUDE.md).
+
+## Tech Stack
+
+- **Framework:** Next.js 15.5.4 with Turbopack
+- **Language:** TypeScript 5
+- **Database:** PostgreSQL via Drizzle ORM
+- **MCP SDK:** @modelcontextprotocol/sdk v1.19.1
+- **Styling:** Tailwind CSS v4
+
+## License
+
+MIT

--- a/app/components/EditStoryModal.tsx
+++ b/app/components/EditStoryModal.tsx
@@ -10,7 +10,6 @@ interface EditStoryModalProps {
     acceptanceCriteria: string | null;
     status: string;
     priority: string;
-    storyPoints: number | null;
   };
   isOpen: boolean;
   onClose: () => void;
@@ -29,7 +28,6 @@ export default function EditStoryModal({
     acceptanceCriteria: story.acceptanceCriteria || '',
     status: story.status,
     priority: story.priority,
-    storyPoints: story.storyPoints || 0,
   });
   const [isSaving, setIsSaving] = useState(false);
 
@@ -114,7 +112,7 @@ export default function EditStoryModal({
                 />
               </div>
 
-              <div className="grid grid-cols-3 gap-4">
+              <div className="grid grid-cols-2 gap-4">
                 <div>
                   <label htmlFor="status" className="block text-sm font-medium text-gray-700 mb-1">
                     Status *
@@ -150,20 +148,6 @@ export default function EditStoryModal({
                     <option value="high">High</option>
                     <option value="critical">Critical</option>
                   </select>
-                </div>
-
-                <div>
-                  <label htmlFor="storyPoints" className="block text-sm font-medium text-gray-700 mb-1">
-                    Story Points
-                  </label>
-                  <input
-                    type="number"
-                    id="storyPoints"
-                    min="0"
-                    value={formData.storyPoints}
-                    onChange={(e) => setFormData({ ...formData, storyPoints: parseInt(e.target.value) || 0 })}
-                    className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
-                  />
                 </div>
               </div>
             </div>

--- a/app/components/EditTaskModal.tsx
+++ b/app/components/EditTaskModal.tsx
@@ -8,8 +8,6 @@ interface EditTaskModalProps {
     title: string;
     description: string | null;
     status: string;
-    estimatedHours: string | null;
-    actualHours: string | null;
   };
   isOpen: boolean;
   onClose: () => void;
@@ -26,8 +24,6 @@ export default function EditTaskModal({
     title: task.title,
     description: task.description || '',
     status: task.status,
-    estimatedHours: task.estimatedHours ? parseFloat(task.estimatedHours) : 0,
-    actualHours: task.actualHours ? parseFloat(task.actualHours) : 0,
   });
   const [isSaving, setIsSaving] = useState(false);
 
@@ -99,54 +95,22 @@ export default function EditTaskModal({
                 />
               </div>
 
-              <div className="grid grid-cols-3 gap-4">
-                <div>
-                  <label htmlFor="status" className="block text-sm font-medium text-gray-700 mb-1">
-                    Status *
-                  </label>
-                  <select
-                    id="status"
-                    required
-                    value={formData.status}
-                    onChange={(e) => setFormData({ ...formData, status: e.target.value })}
-                    className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
-                  >
-                    <option value="todo">To Do</option>
-                    <option value="in_progress">In Progress</option>
-                    <option value="blocked">Blocked</option>
-                    <option value="completed">Completed</option>
-                  </select>
-                </div>
-
-                <div>
-                  <label htmlFor="estimatedHours" className="block text-sm font-medium text-gray-700 mb-1">
-                    Estimated Hours
-                  </label>
-                  <input
-                    type="number"
-                    id="estimatedHours"
-                    min="0"
-                    step="0.5"
-                    value={formData.estimatedHours}
-                    onChange={(e) => setFormData({ ...formData, estimatedHours: parseFloat(e.target.value) || 0 })}
-                    className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
-                  />
-                </div>
-
-                <div>
-                  <label htmlFor="actualHours" className="block text-sm font-medium text-gray-700 mb-1">
-                    Actual Hours
-                  </label>
-                  <input
-                    type="number"
-                    id="actualHours"
-                    min="0"
-                    step="0.5"
-                    value={formData.actualHours}
-                    onChange={(e) => setFormData({ ...formData, actualHours: parseFloat(e.target.value) || 0 })}
-                    className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
-                  />
-                </div>
+              <div>
+                <label htmlFor="status" className="block text-sm font-medium text-gray-700 mb-1">
+                  Status *
+                </label>
+                <select
+                  id="status"
+                  required
+                  value={formData.status}
+                  onChange={(e) => setFormData({ ...formData, status: e.target.value })}
+                  className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+                >
+                  <option value="todo">To Do</option>
+                  <option value="in_progress">In Progress</option>
+                  <option value="blocked">Blocked</option>
+                  <option value="completed">Completed</option>
+                </select>
               </div>
             </div>
 

--- a/app/components/StoryCard.tsx
+++ b/app/components/StoryCard.tsx
@@ -11,7 +11,6 @@ interface StoryCardProps {
   acceptanceCriteria: string | null;
   status: string;
   priority: string;
-  storyPoints: number | null;
   onUpdate?: () => void;
 }
 
@@ -37,7 +36,6 @@ export default function StoryCard({
   acceptanceCriteria,
   status,
   priority,
-  storyPoints,
   onUpdate,
 }: StoryCardProps) {
   const [isEditModalOpen, setIsEditModalOpen] = useState(false);
@@ -91,15 +89,10 @@ export default function StoryCard({
         {description && (
           <p className="text-gray-600 text-sm mb-2 line-clamp-2">{description}</p>
         )}
-        {storyPoints !== null && (
-          <div className="text-xs text-gray-500">
-            Story Points: {storyPoints}
-          </div>
-        )}
       </Link>
 
       <EditStoryModal
-        story={{ id, title, description, acceptanceCriteria, status, priority, storyPoints }}
+        story={{ id, title, description, acceptanceCriteria, status, priority }}
         isOpen={isEditModalOpen}
         onClose={() => setIsEditModalOpen(false)}
         onSave={handleSave}

--- a/app/components/TaskCard.tsx
+++ b/app/components/TaskCard.tsx
@@ -8,8 +8,6 @@ interface TaskCardProps {
   title: string;
   description: string | null;
   status: string;
-  estimatedHours: string | null;
-  actualHours: string | null;
   onUpdate?: () => void;
 }
 
@@ -25,8 +23,6 @@ export default function TaskCard({
   title,
   description,
   status,
-  estimatedHours,
-  actualHours,
   onUpdate,
 }: TaskCardProps) {
   const [isEditModalOpen, setIsEditModalOpen] = useState(false);
@@ -70,22 +66,10 @@ export default function TaskCard({
         {description && (
           <p className="text-gray-600 text-xs mb-2">{description}</p>
         )}
-        <div className="flex gap-4 text-xs text-gray-500">
-          {estimatedHours && (
-            <div>
-              <span className="font-medium">Est:</span> {estimatedHours}h
-            </div>
-          )}
-          {actualHours && (
-            <div>
-              <span className="font-medium">Actual:</span> {actualHours}h
-            </div>
-          )}
-        </div>
       </div>
 
       <EditTaskModal
-        task={{ id, title, description, status, estimatedHours, actualHours }}
+        task={{ id, title, description, status }}
         isOpen={isEditModalOpen}
         onClose={() => setIsEditModalOpen(false)}
         onSave={handleSave}

--- a/app/epics/[id]/page.tsx
+++ b/app/epics/[id]/page.tsx
@@ -25,7 +25,6 @@ interface Story {
   acceptanceCriteria: string | null;
   status: string;
   priority: string;
-  storyPoints: number | null;
   orderIndex: number;
   createdAt: string;
   updatedAt: string;
@@ -232,7 +231,6 @@ export default function EpicDetailPage({
                   acceptanceCriteria={story.acceptanceCriteria}
                   status={story.status}
                   priority={story.priority}
-                  storyPoints={story.storyPoints}
                   onUpdate={handleStoryUpdate}
                 />
               ))}

--- a/app/epics/[id]/page.tsx
+++ b/app/epics/[id]/page.tsx
@@ -215,7 +215,7 @@ export default function EpicDetailPage({
             </svg>
             <h3 className="mt-2 text-sm font-medium text-gray-900">No stories</h3>
             <p className="mt-1 text-sm text-gray-500">
-              This epic doesn't have any stories yet
+              This epic doesn&apos;t have any stories yet
             </p>
           </div>
         ) : (

--- a/app/repos/[id]/page.tsx
+++ b/app/repos/[id]/page.tsx
@@ -225,7 +225,7 @@ export default function RepoDetailPage({
             </svg>
             <h3 className="mt-2 text-sm font-medium text-gray-900">No epics</h3>
             <p className="mt-1 text-sm text-gray-500">
-              This repository doesn't have any epics yet
+              This repository doesn&apos;t have any epics yet
             </p>
           </div>
         ) : (

--- a/app/stories/[id]/page.tsx
+++ b/app/stories/[id]/page.tsx
@@ -200,7 +200,7 @@ export default function StoryDetailPage({
             </svg>
             <h3 className="mt-2 text-sm font-medium text-gray-900">No tasks</h3>
             <p className="mt-1 text-sm text-gray-500">
-              This story doesn't have any tasks yet
+              This story doesn&apos;t have any tasks yet
             </p>
           </div>
         ) : (

--- a/app/stories/[id]/page.tsx
+++ b/app/stories/[id]/page.tsx
@@ -13,7 +13,6 @@ interface Story {
   acceptanceCriteria: string | null;
   status: string;
   priority: string;
-  storyPoints: number | null;
   orderIndex: number;
   createdAt: string;
   updatedAt: string;
@@ -25,8 +24,6 @@ interface Task {
   title: string;
   description: string | null;
   status: string;
-  estimatedHours: string | null;
-  actualHours: string | null;
   orderIndex: number;
   createdAt: string;
   updatedAt: string;
@@ -180,13 +177,6 @@ export default function StoryDetailPage({
           </div>
         )}
 
-        <div className="flex gap-4 text-sm text-gray-600">
-          {story.storyPoints !== null && (
-            <div>
-              <span className="font-medium">Story Points:</span> {story.storyPoints}
-            </div>
-          )}
-        </div>
       </div>
 
       {/* Tasks list */}
@@ -224,8 +214,6 @@ export default function StoryDetailPage({
                   title={task.title}
                   description={task.description}
                   status={task.status}
-                  estimatedHours={task.estimatedHours}
-                  actualHours={task.actualHours}
                   onUpdate={handleTaskUpdate}
                 />
               ))}
@@ -234,7 +222,7 @@ export default function StoryDetailPage({
       </div>
 
       <EditStoryModal
-        story={{ id: story.id, title: story.title, description: story.description, acceptanceCriteria: story.acceptanceCriteria, status: story.status, priority: story.priority, storyPoints: story.storyPoints }}
+        story={{ id: story.id, title: story.title, description: story.description, acceptanceCriteria: story.acceptanceCriteria, status: story.status, priority: story.priority }}
         isOpen={isEditStoryModalOpen}
         onClose={() => setIsEditStoryModalOpen(false)}
         onSave={handleStoryUpdate}

--- a/dist/lib/db/schema.js
+++ b/dist/lib/db/schema.js
@@ -1,4 +1,4 @@
-import { pgTable, text, timestamp, integer, decimal, uuid, pgEnum } from 'drizzle-orm/pg-core';
+import { pgTable, text, timestamp, integer, uuid, pgEnum } from 'drizzle-orm/pg-core';
 import { relations } from 'drizzle-orm';
 // Enums
 export const epicStatusEnum = pgEnum('epic_status', ['draft', 'active', 'completed', 'archived']);
@@ -35,7 +35,6 @@ export const stories = pgTable('stories', {
     acceptanceCriteria: text('acceptance_criteria'),
     status: storyStatusEnum('status').notNull().default('draft'),
     priority: priorityEnum('priority').notNull().default('medium'),
-    storyPoints: integer('story_points'),
     orderIndex: integer('order_index').notNull().default(0),
     createdAt: timestamp('created_at').notNull().defaultNow(),
     updatedAt: timestamp('updated_at').notNull().defaultNow(),
@@ -47,8 +46,6 @@ export const tasks = pgTable('tasks', {
     title: text('title').notNull(),
     description: text('description'),
     status: taskStatusEnum('status').notNull().default('todo'),
-    estimatedHours: decimal('estimated_hours', { precision: 10, scale: 2 }),
-    actualHours: decimal('actual_hours', { precision: 10, scale: 2 }),
     orderIndex: integer('order_index').notNull().default(0),
     createdAt: timestamp('created_at').notNull().defaultNow(),
     updatedAt: timestamp('updated_at').notNull().defaultNow(),

--- a/dist/lib/mcp/tools/upsert-story.js
+++ b/dist/lib/mcp/tools/upsert-story.js
@@ -9,7 +9,6 @@ const upsertStorySchema = z.object({
     acceptanceCriteria: z.string().optional().describe("Acceptance criteria"),
     status: z.enum(['draft', 'ready', 'in_progress', 'review', 'completed']).optional().describe("Story status"),
     priority: z.enum(['low', 'medium', 'high', 'critical']).optional().describe("Story priority"),
-    storyPoints: z.number().int().optional().describe("Story points estimate"),
     orderIndex: z.number().int().optional().describe("Order within epic"),
 });
 export const upsertStoryTool = {
@@ -35,8 +34,6 @@ export const upsertStoryTool = {
                     updateData.status = params.status;
                 if (params.priority !== undefined)
                     updateData.priority = params.priority;
-                if (params.storyPoints !== undefined)
-                    updateData.storyPoints = params.storyPoints;
                 if (params.orderIndex !== undefined)
                     updateData.orderIndex = params.orderIndex;
                 const result = await db
@@ -73,8 +70,6 @@ export const upsertStoryTool = {
                     insertData.status = params.status;
                 if (params.priority !== undefined)
                     insertData.priority = params.priority;
-                if (params.storyPoints !== undefined)
-                    insertData.storyPoints = params.storyPoints;
                 if (params.orderIndex !== undefined)
                     insertData.orderIndex = params.orderIndex;
                 const result = await db.insert(stories).values(insertData).returning();

--- a/dist/lib/mcp/tools/upsert-task.js
+++ b/dist/lib/mcp/tools/upsert-task.js
@@ -7,8 +7,6 @@ const upsertTaskSchema = z.object({
     title: z.string().min(1).describe("Task title"),
     description: z.string().optional().describe("Task description"),
     status: z.enum(['todo', 'in_progress', 'blocked', 'completed']).optional().describe("Task status"),
-    estimatedHours: z.number().optional().describe("Estimated hours to complete"),
-    actualHours: z.number().optional().describe("Actual hours spent"),
     orderIndex: z.number().int().optional().describe("Order within story"),
     completedAt: z.string().datetime().optional().describe("Completion timestamp (ISO 8601)"),
 });
@@ -31,10 +29,6 @@ export const upsertTaskTool = {
                     updateData.description = params.description;
                 if (params.status !== undefined)
                     updateData.status = params.status;
-                if (params.estimatedHours !== undefined)
-                    updateData.estimatedHours = params.estimatedHours.toString();
-                if (params.actualHours !== undefined)
-                    updateData.actualHours = params.actualHours.toString();
                 if (params.orderIndex !== undefined)
                     updateData.orderIndex = params.orderIndex;
                 if (params.completedAt !== undefined)
@@ -69,10 +63,6 @@ export const upsertTaskTool = {
                     insertData.description = params.description;
                 if (params.status !== undefined)
                     insertData.status = params.status;
-                if (params.estimatedHours !== undefined)
-                    insertData.estimatedHours = params.estimatedHours.toString();
-                if (params.actualHours !== undefined)
-                    insertData.actualHours = params.actualHours.toString();
                 if (params.orderIndex !== undefined)
                     insertData.orderIndex = params.orderIndex;
                 if (params.completedAt !== undefined)

--- a/drizzle/0002_previous_betty_ross.sql
+++ b/drizzle/0002_previous_betty_ross.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "stories" DROP COLUMN "story_points";--> statement-breakpoint
+ALTER TABLE "tasks" DROP COLUMN "estimated_hours";--> statement-breakpoint
+ALTER TABLE "tasks" DROP COLUMN "actual_hours";

--- a/drizzle/meta/0002_snapshot.json
+++ b/drizzle/meta/0002_snapshot.json
@@ -1,0 +1,383 @@
+{
+  "id": "a0fe3af6-d448-4be5-b095-f4a1e8b9416e",
+  "prevId": "70e025ef-820a-4877-9052-1d6c013bbc5c",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.epics": {
+      "name": "epics",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "repo_id": {
+          "name": "repo_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "epic_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "priority": {
+          "name": "priority",
+          "type": "priority",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'medium'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "epics_repo_id_repositories_id_fk": {
+          "name": "epics_repo_id_repositories_id_fk",
+          "tableFrom": "epics",
+          "tableTo": "repositories",
+          "columnsFrom": [
+            "repo_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.repositories": {
+      "name": "repositories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "local_path": {
+          "name": "local_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo_url": {
+          "name": "repo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stories": {
+      "name": "stories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "epic_id": {
+          "name": "epic_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "acceptance_criteria": {
+          "name": "acceptance_criteria",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "story_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "priority": {
+          "name": "priority",
+          "type": "priority",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'medium'"
+        },
+        "order_index": {
+          "name": "order_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "stories_epic_id_epics_id_fk": {
+          "name": "stories_epic_id_epics_id_fk",
+          "tableFrom": "stories",
+          "tableTo": "epics",
+          "columnsFrom": [
+            "epic_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tasks": {
+      "name": "tasks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "story_id": {
+          "name": "story_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "task_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'todo'"
+        },
+        "order_index": {
+          "name": "order_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "tasks_story_id_stories_id_fk": {
+          "name": "tasks_story_id_stories_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "stories",
+          "columnsFrom": [
+            "story_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.epic_status": {
+      "name": "epic_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "active",
+        "completed",
+        "archived"
+      ]
+    },
+    "public.priority": {
+      "name": "priority",
+      "schema": "public",
+      "values": [
+        "low",
+        "medium",
+        "high",
+        "critical"
+      ]
+    },
+    "public.story_status": {
+      "name": "story_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "ready",
+        "in_progress",
+        "review",
+        "completed"
+      ]
+    },
+    "public.task_status": {
+      "name": "task_status",
+      "schema": "public",
+      "values": [
+        "todo",
+        "in_progress",
+        "blocked",
+        "completed"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1759796166296,
       "tag": "0001_aromatic_switch",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1759806206524,
+      "tag": "0002_previous_betty_ross",
+      "breakpoints": true
     }
   ]
 }

--- a/lib/db/__tests__/schema.test.ts
+++ b/lib/db/__tests__/schema.test.ts
@@ -34,7 +34,6 @@ describe('Database Schema', () => {
       expect(storyFields).toContain('acceptanceCriteria');
       expect(storyFields).toContain('status');
       expect(storyFields).toContain('priority');
-      expect(storyFields).toContain('storyPoints');
       expect(storyFields).toContain('orderIndex');
     });
   });
@@ -51,8 +50,6 @@ describe('Database Schema', () => {
       expect(taskFields).toContain('title');
       expect(taskFields).toContain('description');
       expect(taskFields).toContain('status');
-      expect(taskFields).toContain('estimatedHours');
-      expect(taskFields).toContain('actualHours');
       expect(taskFields).toContain('orderIndex');
       expect(taskFields).toContain('completedAt');
     });

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -1,4 +1,4 @@
-import { pgTable, text, timestamp, integer, decimal, uuid, pgEnum } from 'drizzle-orm/pg-core';
+import { pgTable, text, timestamp, integer, uuid, pgEnum } from 'drizzle-orm/pg-core';
 import { relations } from 'drizzle-orm';
 
 // Enums
@@ -39,7 +39,6 @@ export const stories = pgTable('stories', {
   acceptanceCriteria: text('acceptance_criteria'),
   status: storyStatusEnum('status').notNull().default('draft'),
   priority: priorityEnum('priority').notNull().default('medium'),
-  storyPoints: integer('story_points'),
   orderIndex: integer('order_index').notNull().default(0),
   createdAt: timestamp('created_at').notNull().defaultNow(),
   updatedAt: timestamp('updated_at').notNull().defaultNow(),
@@ -52,8 +51,6 @@ export const tasks = pgTable('tasks', {
   title: text('title').notNull(),
   description: text('description'),
   status: taskStatusEnum('status').notNull().default('todo'),
-  estimatedHours: decimal('estimated_hours', { precision: 10, scale: 2 }),
-  actualHours: decimal('actual_hours', { precision: 10, scale: 2 }),
   orderIndex: integer('order_index').notNull().default(0),
   createdAt: timestamp('created_at').notNull().defaultNow(),
   updatedAt: timestamp('updated_at').notNull().defaultNow(),

--- a/lib/mcp/tools/upsert-story.ts
+++ b/lib/mcp/tools/upsert-story.ts
@@ -11,7 +11,6 @@ const upsertStorySchema = z.object({
   acceptanceCriteria: z.string().optional().describe("Acceptance criteria"),
   status: z.enum(['draft', 'ready', 'in_progress', 'review', 'completed']).optional().describe("Story status"),
   priority: z.enum(['low', 'medium', 'high', 'critical']).optional().describe("Story priority"),
-  storyPoints: z.number().int().optional().describe("Story points estimate"),
   orderIndex: z.number().int().optional().describe("Order within epic"),
 });
 
@@ -33,7 +32,6 @@ export const upsertStoryTool: ToolDefinition = {
         if (params.acceptanceCriteria !== undefined) updateData.acceptanceCriteria = params.acceptanceCriteria;
         if (params.status !== undefined) updateData.status = params.status;
         if (params.priority !== undefined) updateData.priority = params.priority;
-        if (params.storyPoints !== undefined) updateData.storyPoints = params.storyPoints;
         if (params.orderIndex !== undefined) updateData.orderIndex = params.orderIndex;
 
         const result = await db
@@ -68,7 +66,6 @@ export const upsertStoryTool: ToolDefinition = {
         if (params.acceptanceCriteria !== undefined) insertData.acceptanceCriteria = params.acceptanceCriteria;
         if (params.status !== undefined) insertData.status = params.status;
         if (params.priority !== undefined) insertData.priority = params.priority;
-        if (params.storyPoints !== undefined) insertData.storyPoints = params.storyPoints;
         if (params.orderIndex !== undefined) insertData.orderIndex = params.orderIndex;
 
         const result = await db.insert(stories).values(insertData).returning();

--- a/lib/mcp/tools/upsert-task.ts
+++ b/lib/mcp/tools/upsert-task.ts
@@ -9,8 +9,6 @@ const upsertTaskSchema = z.object({
   title: z.string().min(1).describe("Task title"),
   description: z.string().optional().describe("Task description"),
   status: z.enum(['todo', 'in_progress', 'blocked', 'completed']).optional().describe("Task status"),
-  estimatedHours: z.number().optional().describe("Estimated hours to complete"),
-  actualHours: z.number().optional().describe("Actual hours spent"),
   orderIndex: z.number().int().optional().describe("Order within story"),
   completedAt: z.string().datetime().optional().describe("Completion timestamp (ISO 8601)"),
 });
@@ -31,8 +29,6 @@ export const upsertTaskTool: ToolDefinition = {
         if (params.title !== undefined) updateData.title = params.title;
         if (params.description !== undefined) updateData.description = params.description;
         if (params.status !== undefined) updateData.status = params.status;
-        if (params.estimatedHours !== undefined) updateData.estimatedHours = params.estimatedHours.toString();
-        if (params.actualHours !== undefined) updateData.actualHours = params.actualHours.toString();
         if (params.orderIndex !== undefined) updateData.orderIndex = params.orderIndex;
         if (params.completedAt !== undefined) updateData.completedAt = new Date(params.completedAt);
 
@@ -66,8 +62,6 @@ export const upsertTaskTool: ToolDefinition = {
 
         if (params.description !== undefined) insertData.description = params.description;
         if (params.status !== undefined) insertData.status = params.status;
-        if (params.estimatedHours !== undefined) insertData.estimatedHours = params.estimatedHours.toString();
-        if (params.actualHours !== undefined) insertData.actualHours = params.actualHours.toString();
         if (params.orderIndex !== undefined) insertData.orderIndex = params.orderIndex;
         if (params.completedAt !== undefined) insertData.completedAt = new Date(params.completedAt);
 


### PR DESCRIPTION
## Summary
- Removed storyPoints field from stories table
- Removed estimatedHours and actualHours fields from tasks table
- Updated MCP tools to remove references to deleted fields
- Updated all UI components and forms to remove estimation fields
- Updated documentation (CLAUDE.md and README.md)

## Rationale
These fields don't provide value in the AI-driven workflow context. The application now has a cleaner, more focused schema without unnecessary estimation tracking.

## Changes
- Database migration to drop 3 columns
- MCP tools updated (upsert-story.ts, upsert-task.ts)
- UI components updated (StoryCard, TaskCard, EditStoryModal, EditTaskModal)
- Pages updated (epic detail, story detail)
- Documentation fully updated with database setup instructions

## Test Plan
- [x] Database migration applied successfully
- [x] MCP server rebuilt and tested
- [x] Created test epic, story, and task - no estimation fields present
- [x] TypeScript compilation successful
- [x] All changes committed and pushed

🤖 Generated with [Claude Code](https://claude.com/claude-code)