### PR TITLE
Fix TypeScript errors in API route handlers

### DIFF
--- a/app/api/epics/route.ts
+++ b/app/api/epics/route.ts
@@ -3,6 +3,8 @@ import { db } from '@/lib/db';
 import { epics } from '@/lib/db/schema';
 import { eq } from 'drizzle-orm';
 
+type EpicStatus = 'draft' | 'active' | 'completed' | 'archived';
+
 export async function GET(request: NextRequest) {
   try {
     const searchParams = request.nextUrl.searchParams;
@@ -10,7 +12,7 @@ export async function GET(request: NextRequest) {
 
     let result;
     if (status) {
-      result = await db.select().from(epics).where(eq(epics.status, status));
+      result = await db.select().from(epics).where(eq(epics.status, status as EpicStatus));
     } else {
       result = await db.select().from(epics);
     }

--- a/app/api/stories/route.ts
+++ b/app/api/stories/route.ts
@@ -1,7 +1,9 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { db } from '@/lib/db';
 import { stories } from '@/lib/db/schema';
-import { eq } from 'drizzle-orm';
+import { eq, and } from 'drizzle-orm';
+
+type StoryStatus = 'draft' | 'ready' | 'in_progress' | 'review' | 'completed';
 
 export async function GET(request: NextRequest) {
   try {
@@ -14,12 +16,14 @@ export async function GET(request: NextRequest) {
       result = await db
         .select()
         .from(stories)
-        .where(eq(stories.epicId, epicId))
-        .where(eq(stories.status, status));
+        .where(and(
+          eq(stories.epicId, epicId),
+          eq(stories.status, status as StoryStatus)
+        ));
     } else if (epicId) {
       result = await db.select().from(stories).where(eq(stories.epicId, epicId));
     } else if (status) {
-      result = await db.select().from(stories).where(eq(stories.status, status));
+      result = await db.select().from(stories).where(eq(stories.status, status as StoryStatus));
     } else {
       result = await db.select().from(stories);
     }

--- a/app/api/tasks/route.ts
+++ b/app/api/tasks/route.ts
@@ -1,7 +1,9 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { db } from '@/lib/db';
 import { tasks } from '@/lib/db/schema';
-import { eq } from 'drizzle-orm';
+import { eq, and } from 'drizzle-orm';
+
+type TaskStatus = 'todo' | 'in_progress' | 'blocked' | 'completed';
 
 export async function GET(request: NextRequest) {
   try {
@@ -14,12 +16,14 @@ export async function GET(request: NextRequest) {
       result = await db
         .select()
         .from(tasks)
-        .where(eq(tasks.storyId, storyId))
-        .where(eq(tasks.status, status));
+        .where(and(
+          eq(tasks.storyId, storyId),
+          eq(tasks.status, status as TaskStatus)
+        ));
     } else if (storyId) {
       result = await db.select().from(tasks).where(eq(tasks.storyId, storyId));
     } else if (status) {
-      result = await db.select().from(tasks).where(eq(tasks.status, status));
+      result = await db.select().from(tasks).where(eq(tasks.status, status as TaskStatus));
     } else {
       result = await db.select().from(tasks);
     }


### PR DESCRIPTION
## Summary
- Fix TypeScript compilation errors in API route handlers (epics, stories, tasks)
- Add proper type definitions for enum status parameters
- Replace chained `.where()` calls with `and()` combinator
- Resolve type mismatches preventing successful builds

## Changes
- **app/api/epics/route.ts**: Added `EpicStatus` type and type casting
- **app/api/stories/route.ts**: Added `StoryStatus` type, type casting, and `and()` combinator
- **app/api/tasks/route.ts**: Added `TaskStatus` type, type casting, and `and()` combinator

## Testing
- ✅ TypeScript compilation passes (`npx tsc --noEmit`)
- ✅ Production build succeeds (`npm run build`)
- ✅ Linting passes with 0 errors (`npm run lint`)
- ✅ No breaking changes to API functionality

## Related
Fixes Epic: Fix TypeScript Errors in API Routes (ebe351c6-543d-4ba1-b6ba-c25c598f2e06)

🤖 Generated with [Claude Code](https://claude.com/claude-code)