### PR TITLE
Update PostgreSQL port to 5433

### DIFF
--- a/.env
+++ b/.env
@@ -1,6 +1,6 @@
 # Database connection for local PostgreSQL
 # Default credentials for local development only
-DATABASE_URL=postgresql://postgres:postgres@localhost:5432/spec_this
+DATABASE_URL=postgresql://postgres:postgres@localhost:5433/spec_this
 
 # Neo4j connection for file dependency graph
 NEO4J_URI=bolt://localhost:7687

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       POSTGRES_PASSWORD: postgres
       POSTGRES_DB: spec_this
     ports:
-      - "5432:5432"
+      - "5433:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data
     healthcheck:


### PR DESCRIPTION
Changed PostgreSQL port from 5432 to 5433 in both docker-compose.yml and .env to avoid port conflicts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)