### PR TITLE
Add MCP tools for deleting stories and files

### DIFF
--- a/lib/mcp/tools/delete-planned-file-change.ts
+++ b/lib/mcp/tools/delete-planned-file-change.ts
@@ -1,0 +1,45 @@
+import { z } from "zod";
+import { eq } from "drizzle-orm";
+import { db, plannedFileChanges } from "../../db/index.ts";
+import type { ToolDefinition } from "../types/tool.ts";
+
+const deletePlannedFileChangeSchema = z.object({
+  id: z.string().uuid().describe("Planned file change ID to delete"),
+});
+
+export const deletePlannedFileChangeTool: ToolDefinition = {
+  name: "delete_planned_file_change",
+  description: "Delete a planned file change by ID.",
+  schema: deletePlannedFileChangeSchema,
+  handler: async (params) => {
+    try {
+      const result = await db
+        .delete(plannedFileChanges)
+        .where(eq(plannedFileChanges.id, params.id))
+        .returning();
+
+      if (result.length === 0) {
+        return {
+          content: [{
+            type: "text",
+            text: `No planned file change found with ID: ${params.id}`,
+          }],
+        };
+      }
+
+      return {
+        content: [{
+          type: "text",
+          text: `Planned file change deleted successfully:\n${JSON.stringify(result[0], null, 2)}`,
+        }],
+      };
+    } catch (error) {
+      return {
+        content: [{
+          type: "text",
+          text: `Error deleting planned file change: ${error instanceof Error ? error.message : String(error)}`,
+        }],
+      };
+    }
+  },
+};

--- a/lib/mcp/tools/delete-story.ts
+++ b/lib/mcp/tools/delete-story.ts
@@ -1,0 +1,45 @@
+import { z } from "zod";
+import { eq } from "drizzle-orm";
+import { db, stories } from "../../db/index.ts";
+import type { ToolDefinition } from "../types/tool.ts";
+
+const deleteStorySchema = z.object({
+  id: z.string().uuid().describe("Story ID to delete"),
+});
+
+export const deleteStoryTool: ToolDefinition = {
+  name: "delete_story",
+  description: "Delete a story by ID. This will cascade delete all associated planned file changes.",
+  schema: deleteStorySchema,
+  handler: async (params) => {
+    try {
+      const result = await db
+        .delete(stories)
+        .where(eq(stories.id, params.id))
+        .returning();
+
+      if (result.length === 0) {
+        return {
+          content: [{
+            type: "text",
+            text: `No story found with ID: ${params.id}`,
+          }],
+        };
+      }
+
+      return {
+        content: [{
+          type: "text",
+          text: `Story deleted successfully:\n${JSON.stringify(result[0], null, 2)}`,
+        }],
+      };
+    } catch (error) {
+      return {
+        content: [{
+          type: "text",
+          text: `Error deleting story: ${error instanceof Error ? error.message : String(error)}`,
+        }],
+      };
+    }
+  },
+};

--- a/lib/mcp/tools/index.ts
+++ b/lib/mcp/tools/index.ts
@@ -4,8 +4,10 @@ import { readEpicsTool } from "./read-epics.ts";
 import { upsertEpicTool } from "./upsert-epic.ts";
 import { readStoriesTool } from "./read-stories.ts";
 import { upsertStoryTool } from "./upsert-story.ts";
+import { deleteStoryTool } from "./delete-story.ts";
 import { readPlannedFileChangesTool } from "./read-planned-file-changes.ts";
 import { upsertPlannedFileChangeTool } from "./upsert-planned-file-change.ts";
+import { deletePlannedFileChangeTool } from "./delete-planned-file-change.ts";
 import { echoTool } from "./echo.ts";
 
 export const allTools: ToolDefinition[] = [
@@ -15,8 +17,10 @@ export const allTools: ToolDefinition[] = [
   upsertEpicTool,
   readStoriesTool,
   upsertStoryTool,
+  deleteStoryTool,
   readPlannedFileChangesTool,
   upsertPlannedFileChangeTool,
+  deletePlannedFileChangeTool,
 ];
 
 export * from "./echo.ts";
@@ -25,5 +29,7 @@ export * from "./read-epics.ts";
 export * from "./upsert-epic.ts";
 export * from "./read-stories.ts";
 export * from "./upsert-story.ts";
+export * from "./delete-story.ts";
 export * from "./read-planned-file-changes.ts";
 export * from "./upsert-planned-file-change.ts";
+export * from "./delete-planned-file-change.ts";


### PR DESCRIPTION
Implements two new MCP tools:
- delete_story: Deletes a story by ID with cascade to planned file changes
- delete_planned_file_change: Deletes a planned file change by ID

Both tools follow existing patterns with Zod validation and proper error handling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)