### PR TITLE
Create quick task planning process

### DIFF
--- a/app/api/quick-tasks/route.ts
+++ b/app/api/quick-tasks/route.ts
@@ -1,0 +1,135 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { db } from '@/lib/db';
+import { quickTasks } from '@/lib/db/schema';
+import { eq } from 'drizzle-orm';
+
+type QuickTaskStatus = 'planned' | 'in_progress' | 'completed' | 'cancelled';
+
+export async function GET(request: NextRequest) {
+  try {
+    const searchParams = request.nextUrl.searchParams;
+    const status = searchParams.get('status');
+    const repoId = searchParams.get('repoId');
+
+    let result;
+    if (status && repoId) {
+      result = await db.select().from(quickTasks)
+        .where(eq(quickTasks.status, status as QuickTaskStatus))
+        .where(eq(quickTasks.repoId, repoId));
+    } else if (status) {
+      result = await db.select().from(quickTasks)
+        .where(eq(quickTasks.status, status as QuickTaskStatus));
+    } else if (repoId) {
+      result = await db.select().from(quickTasks)
+        .where(eq(quickTasks.repoId, repoId));
+    } else {
+      result = await db.select().from(quickTasks);
+    }
+
+    return NextResponse.json(result, { status: 200 });
+  } catch (error) {
+    console.error('Error fetching quick tasks:', error);
+    return NextResponse.json(
+      { error: 'Failed to fetch quick tasks' },
+      { status: 500 }
+    );
+  }
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const { repoId, title, description, status, priority } = body;
+
+    if (!repoId || !title) {
+      return NextResponse.json(
+        { error: 'Repository ID and title are required' },
+        { status: 400 }
+      );
+    }
+
+    const result = await db.insert(quickTasks).values({
+      repoId,
+      title,
+      description,
+      status: status || 'planned',
+      priority: priority || 'medium',
+    }).returning();
+
+    return NextResponse.json(result[0], { status: 201 });
+  } catch (error) {
+    console.error('Error creating quick task:', error);
+    return NextResponse.json(
+      { error: 'Failed to create quick task' },
+      { status: 500 }
+    );
+  }
+}
+
+export async function PATCH(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const { id, ...updates } = body;
+
+    if (!id) {
+      return NextResponse.json(
+        { error: 'Quick task ID is required' },
+        { status: 400 }
+      );
+    }
+
+    // Set completedAt if status is being changed to completed
+    if (updates.status === 'completed' && !updates.completedAt) {
+      updates.completedAt = new Date();
+    }
+
+    const result = await db
+      .update(quickTasks)
+      .set({ ...updates, updatedAt: new Date() })
+      .where(eq(quickTasks.id, id))
+      .returning();
+
+    if (result.length === 0) {
+      return NextResponse.json({ error: 'Quick task not found' }, { status: 404 });
+    }
+
+    return NextResponse.json(result[0], { status: 200 });
+  } catch (error) {
+    console.error('Error updating quick task:', error);
+    return NextResponse.json(
+      { error: 'Failed to update quick task' },
+      { status: 500 }
+    );
+  }
+}
+
+export async function DELETE(request: NextRequest) {
+  try {
+    const searchParams = request.nextUrl.searchParams;
+    const id = searchParams.get('id');
+
+    if (!id) {
+      return NextResponse.json(
+        { error: 'Quick task ID is required' },
+        { status: 400 }
+      );
+    }
+
+    const result = await db
+      .delete(quickTasks)
+      .where(eq(quickTasks.id, id))
+      .returning();
+
+    if (result.length === 0) {
+      return NextResponse.json({ error: 'Quick task not found' }, { status: 404 });
+    }
+
+    return NextResponse.json({ success: true }, { status: 200 });
+  } catch (error) {
+    console.error('Error deleting quick task:', error);
+    return NextResponse.json(
+      { error: 'Failed to delete quick task' },
+      { status: 500 }
+    );
+  }
+}

--- a/app/components/CreateQuickTaskModal.tsx
+++ b/app/components/CreateQuickTaskModal.tsx
@@ -1,0 +1,162 @@
+'use client';
+
+import { useState } from 'react';
+
+interface CreateQuickTaskModalProps {
+  repoId: string;
+  isOpen: boolean;
+  onClose: () => void;
+  onSave: () => void;
+}
+
+const statusOptions = ['planned', 'in_progress', 'completed', 'cancelled'];
+const priorityOptions = ['low', 'medium', 'high', 'critical'];
+
+export default function CreateQuickTaskModal({
+  repoId,
+  isOpen,
+  onClose,
+  onSave,
+}: CreateQuickTaskModalProps) {
+  const [title, setTitle] = useState('');
+  const [description, setDescription] = useState('');
+  const [status, setStatus] = useState('planned');
+  const [priority, setPriority] = useState('medium');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setIsSubmitting(true);
+
+    try {
+      const response = await fetch('/api/quick-tasks', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          repoId,
+          title,
+          description: description || null,
+          status,
+          priority,
+        }),
+      });
+
+      if (!response.ok) {
+        throw new Error('Failed to create quick task');
+      }
+
+      setTitle('');
+      setDescription('');
+      setStatus('planned');
+      setPriority('medium');
+      onSave();
+      onClose();
+    } catch (error) {
+      console.error('Error creating quick task:', error);
+      alert('Failed to create quick task');
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+      <div className="bg-white rounded-lg shadow-xl p-6 w-full max-w-md">
+        <h2 className="text-xl font-bold text-gray-900 mb-4">Create Quick Task</h2>
+        <p className="text-sm text-gray-600 mb-4">
+          Quick tasks are lightweight tasks for small changes that can be planned and executed quickly.
+        </p>
+        <form onSubmit={handleSubmit}>
+          <div className="space-y-4">
+            <div>
+              <label htmlFor="title" className="block text-sm font-medium text-gray-700 mb-1">
+                Title *
+              </label>
+              <input
+                type="text"
+                id="title"
+                value={title}
+                onChange={(e) => setTitle(e.target.value)}
+                className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+                required
+              />
+            </div>
+
+            <div>
+              <label htmlFor="description" className="block text-sm font-medium text-gray-700 mb-1">
+                Description
+              </label>
+              <textarea
+                id="description"
+                value={description}
+                onChange={(e) => setDescription(e.target.value)}
+                rows={3}
+                className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+                placeholder="What needs to be done?"
+              />
+            </div>
+
+            <div className="grid grid-cols-2 gap-4">
+              <div>
+                <label htmlFor="status" className="block text-sm font-medium text-gray-700 mb-1">
+                  Status
+                </label>
+                <select
+                  id="status"
+                  value={status}
+                  onChange={(e) => setStatus(e.target.value)}
+                  className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+                >
+                  {statusOptions.map((opt) => (
+                    <option key={opt} value={opt}>
+                      {opt.replace('_', ' ')}
+                    </option>
+                  ))}
+                </select>
+              </div>
+
+              <div>
+                <label htmlFor="priority" className="block text-sm font-medium text-gray-700 mb-1">
+                  Priority
+                </label>
+                <select
+                  id="priority"
+                  value={priority}
+                  onChange={(e) => setPriority(e.target.value)}
+                  className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+                >
+                  {priorityOptions.map((opt) => (
+                    <option key={opt} value={opt}>
+                      {opt}
+                    </option>
+                  ))}
+                </select>
+              </div>
+            </div>
+          </div>
+
+          <div className="flex justify-end gap-3 mt-6">
+            <button
+              type="button"
+              onClick={onClose}
+              className="px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              disabled={isSubmitting}
+              className="px-4 py-2 text-sm font-medium text-white bg-blue-600 rounded-md hover:bg-blue-700 disabled:bg-gray-400 disabled:cursor-not-allowed"
+            >
+              {isSubmitting ? 'Creating...' : 'Create Quick Task'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/app/components/QuickTaskCard.tsx
+++ b/app/components/QuickTaskCard.tsx
@@ -1,0 +1,176 @@
+'use client';
+
+import { useState } from 'react';
+
+interface QuickTaskCardProps {
+  id: string;
+  title: string;
+  description: string | null;
+  status: string;
+  priority: string;
+  createdAt: string;
+  onUpdate: () => void;
+  onDelete: () => void;
+}
+
+export default function QuickTaskCard({
+  id,
+  title,
+  description,
+  status,
+  priority,
+  createdAt,
+  onUpdate,
+  onDelete,
+}: QuickTaskCardProps) {
+  const [isDeleting, setIsDeleting] = useState(false);
+  const [isUpdating, setIsUpdating] = useState(false);
+
+  const statusColors = {
+    planned: 'bg-gray-100 text-gray-800',
+    in_progress: 'bg-blue-100 text-blue-800',
+    completed: 'bg-green-100 text-green-800',
+    cancelled: 'bg-red-100 text-red-800',
+  };
+
+  const priorityColors = {
+    low: 'bg-blue-100 text-blue-800',
+    medium: 'bg-yellow-100 text-yellow-800',
+    high: 'bg-orange-100 text-orange-800',
+    critical: 'bg-red-100 text-red-800',
+  };
+
+  const handleDelete = async () => {
+    if (!confirm('Are you sure you want to delete this quick task?')) {
+      return;
+    }
+
+    setIsDeleting(true);
+    try {
+      const response = await fetch(`/api/quick-tasks?id=${id}`, {
+        method: 'DELETE',
+      });
+
+      if (!response.ok) {
+        throw new Error('Failed to delete quick task');
+      }
+
+      onDelete();
+    } catch (error) {
+      console.error('Error deleting quick task:', error);
+      alert('Failed to delete quick task');
+    } finally {
+      setIsDeleting(false);
+    }
+  };
+
+  const handleToggleStatus = async () => {
+    setIsUpdating(true);
+    const newStatus = status === 'completed' ? 'planned' : 'completed';
+
+    try {
+      const response = await fetch('/api/quick-tasks', {
+        method: 'PATCH',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ id, status: newStatus }),
+      });
+
+      if (!response.ok) {
+        throw new Error('Failed to update quick task');
+      }
+
+      onUpdate();
+    } catch (error) {
+      console.error('Error updating quick task:', error);
+      alert('Failed to update quick task');
+    } finally {
+      setIsUpdating(false);
+    }
+  };
+
+  const formattedDate = new Date(createdAt).toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  });
+
+  return (
+    <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-4 hover:shadow-md transition-shadow">
+      <div className="flex items-start justify-between mb-2">
+        <h3 className="text-lg font-semibold text-gray-900 flex-1">{title}</h3>
+        <div className="flex items-center gap-2 ml-2">
+          <button
+            onClick={handleToggleStatus}
+            disabled={isUpdating}
+            className={`p-1.5 rounded transition-colors ${
+              status === 'completed'
+                ? 'text-green-600 hover:bg-green-50'
+                : 'text-gray-400 hover:bg-gray-100'
+            } disabled:opacity-50`}
+            title={status === 'completed' ? 'Mark as incomplete' : 'Mark as complete'}
+          >
+            <svg
+              className="w-5 h-5"
+              fill={status === 'completed' ? 'currentColor' : 'none'}
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M5 13l4 4L19 7"
+              />
+            </svg>
+          </button>
+          <button
+            onClick={handleDelete}
+            disabled={isDeleting}
+            className="p-1.5 text-gray-400 hover:text-red-600 hover:bg-red-50 rounded transition-colors disabled:opacity-50"
+            title="Delete quick task"
+          >
+            <svg
+              className="w-5 h-5"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
+              />
+            </svg>
+          </button>
+        </div>
+      </div>
+
+      {description && (
+        <p className="text-sm text-gray-600 mb-3 line-clamp-2">{description}</p>
+      )}
+
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <span
+            className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${
+              statusColors[status as keyof typeof statusColors] || statusColors.planned
+            }`}
+          >
+            {status.replace('_', ' ')}
+          </span>
+          <span
+            className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${
+              priorityColors[priority as keyof typeof priorityColors] || priorityColors.medium
+            }`}
+          >
+            {priority}
+          </span>
+        </div>
+        <span className="text-xs text-gray-500">{formattedDate}</span>
+      </div>
+    </div>
+  );
+}

--- a/drizzle/0005_add_quick_tasks.sql
+++ b/drizzle/0005_add_quick_tasks.sql
@@ -1,0 +1,37 @@
+-- Add quick tasks functionality
+
+-- Create quick_task_status enum
+CREATE TYPE "public"."quick_task_status" AS ENUM('planned', 'in_progress', 'completed', 'cancelled');--> statement-breakpoint
+
+-- Create quick_tasks table
+CREATE TABLE "quick_tasks" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"repo_id" uuid NOT NULL,
+	"title" text NOT NULL,
+	"description" text,
+	"status" "quick_task_status" DEFAULT 'planned' NOT NULL,
+	"priority" "priority" DEFAULT 'medium' NOT NULL,
+	"order_index" integer DEFAULT 0 NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL,
+	"completed_at" timestamp
+);--> statement-breakpoint
+
+-- Add foreign key constraint for quick_tasks
+ALTER TABLE "quick_tasks" ADD CONSTRAINT "quick_tasks_repo_id_repositories_id_fk" FOREIGN KEY ("repo_id") REFERENCES "public"."repositories"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+
+-- Modify planned_file_changes to support both stories and quick tasks
+-- First, make story_id nullable
+ALTER TABLE "planned_file_changes" ALTER COLUMN "story_id" DROP NOT NULL;--> statement-breakpoint
+
+-- Add quick_task_id column
+ALTER TABLE "planned_file_changes" ADD COLUMN "quick_task_id" uuid;--> statement-breakpoint
+
+-- Add foreign key constraint for quick_task_id
+ALTER TABLE "planned_file_changes" ADD CONSTRAINT "planned_file_changes_quick_task_id_quick_tasks_id_fk" FOREIGN KEY ("quick_task_id") REFERENCES "public"."quick_tasks"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+
+-- Add check constraint to ensure either story_id or quick_task_id is set (but not both)
+ALTER TABLE "planned_file_changes" ADD CONSTRAINT "planned_file_changes_parent_check" CHECK (
+	(story_id IS NOT NULL AND quick_task_id IS NULL) OR
+	(story_id IS NULL AND quick_task_id IS NOT NULL)
+);--> statement-breakpoint

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1761088867380,
       "tag": "0004_add_planned_file_changes",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "7",
+      "when": 1730476800000,
+      "tag": "0005_add_quick_tasks",
+      "breakpoints": true
     }
   ]
 }

--- a/lib/mcp/tools/delete-quick-task.ts
+++ b/lib/mcp/tools/delete-quick-task.ts
@@ -1,0 +1,45 @@
+import { z } from "zod";
+import { eq } from "drizzle-orm";
+import { db, quickTasks } from "../../db/index.ts";
+import type { ToolDefinition } from "../types/tool.ts";
+
+const deleteQuickTaskSchema = z.object({
+  id: z.string().uuid().describe("Quick task ID to delete"),
+});
+
+export const deleteQuickTaskTool: ToolDefinition = {
+  name: "delete_quick_task",
+  description: "Delete a quick task by ID. This will cascade delete all associated planned file changes.",
+  schema: deleteQuickTaskSchema,
+  handler: async (params) => {
+    try {
+      const result = await db
+        .delete(quickTasks)
+        .where(eq(quickTasks.id, params.id))
+        .returning();
+
+      if (result.length === 0) {
+        return {
+          content: [{
+            type: "text",
+            text: `No quick task found with ID: ${params.id}`,
+          }],
+        };
+      }
+
+      return {
+        content: [{
+          type: "text",
+          text: `Quick task deleted successfully:\n${JSON.stringify(result[0], null, 2)}`,
+        }],
+      };
+    } catch (error) {
+      return {
+        content: [{
+          type: "text",
+          text: `Error deleting quick task: ${error instanceof Error ? error.message : String(error)}`,
+        }],
+      };
+    }
+  },
+};

--- a/lib/mcp/tools/index.ts
+++ b/lib/mcp/tools/index.ts
@@ -5,6 +5,9 @@ import { upsertEpicTool } from "./upsert-epic.ts";
 import { readStoriesTool } from "./read-stories.ts";
 import { upsertStoryTool } from "./upsert-story.ts";
 import { deleteStoryTool } from "./delete-story.ts";
+import { readQuickTasksTool } from "./read-quick-tasks.ts";
+import { upsertQuickTaskTool } from "./upsert-quick-task.ts";
+import { deleteQuickTaskTool } from "./delete-quick-task.ts";
 import { readPlannedFileChangesTool } from "./read-planned-file-changes.ts";
 import { upsertPlannedFileChangeTool } from "./upsert-planned-file-change.ts";
 import { deletePlannedFileChangeTool } from "./delete-planned-file-change.ts";
@@ -18,6 +21,9 @@ export const allTools: ToolDefinition[] = [
   readStoriesTool,
   upsertStoryTool,
   deleteStoryTool,
+  readQuickTasksTool,
+  upsertQuickTaskTool,
+  deleteQuickTaskTool,
   readPlannedFileChangesTool,
   upsertPlannedFileChangeTool,
   deletePlannedFileChangeTool,
@@ -30,6 +36,9 @@ export * from "./upsert-epic.ts";
 export * from "./read-stories.ts";
 export * from "./upsert-story.ts";
 export * from "./delete-story.ts";
+export * from "./read-quick-tasks.ts";
+export * from "./upsert-quick-task.ts";
+export * from "./delete-quick-task.ts";
 export * from "./read-planned-file-changes.ts";
 export * from "./upsert-planned-file-change.ts";
 export * from "./delete-planned-file-change.ts";

--- a/lib/mcp/tools/read-planned-file-changes.ts
+++ b/lib/mcp/tools/read-planned-file-changes.ts
@@ -6,12 +6,13 @@ import type { ToolDefinition } from "../types/tool.ts";
 const readPlannedFileChangesSchema = z.object({
   id: z.string().uuid().optional().describe("Optional planned file change ID to fetch a specific change"),
   storyId: z.string().uuid().optional().describe("Optional story ID to filter planned file changes by story"),
+  quickTaskId: z.string().uuid().optional().describe("Optional quick task ID to filter planned file changes by quick task"),
   status: z.enum(['planned', 'in_progress', 'completed', 'failed']).optional().describe("Optional status filter"),
 });
 
 export const readPlannedFileChangesTool: ToolDefinition = {
   name: "read_planned_file_changes",
-  description: "Read planned file changes from the database. Can fetch all planned file changes, filter by story ID, status, or get a specific change by ID.",
+  description: "Read planned file changes from the database. Can fetch all planned file changes, filter by story ID, quick task ID, status, or get a specific change by ID.",
   schema: readPlannedFileChangesSchema,
   handler: async (params) => {
     try {
@@ -39,6 +40,7 @@ export const readPlannedFileChangesTool: ToolDefinition = {
       // Build conditions
       const conditions = [];
       if (params.storyId) conditions.push(eq(plannedFileChanges.storyId, params.storyId));
+      if (params.quickTaskId) conditions.push(eq(plannedFileChanges.quickTaskId, params.quickTaskId));
       if (params.status) conditions.push(eq(plannedFileChanges.status, params.status));
 
       let query;

--- a/lib/mcp/tools/read-quick-tasks.ts
+++ b/lib/mcp/tools/read-quick-tasks.ts
@@ -1,0 +1,68 @@
+import { z } from "zod";
+import { eq, and } from "drizzle-orm";
+import { db, quickTasks } from "../../db/index.ts";
+import type { ToolDefinition } from "../types/tool.ts";
+
+const readQuickTasksSchema = z.object({
+  id: z.string().uuid().optional().describe("Optional quick task ID to fetch a specific quick task"),
+  repoId: z.string().uuid().optional().describe("Optional repository ID to filter quick tasks by repository"),
+  status: z.enum(['planned', 'in_progress', 'completed', 'cancelled']).optional().describe("Optional status filter"),
+});
+
+export const readQuickTasksTool: ToolDefinition = {
+  name: "read_quick_tasks",
+  description: "Read quick tasks from the database. Can fetch all quick tasks, filter by repository ID, status, or get a specific quick task by ID. Quick tasks are lightweight tasks that belong directly to a repository and are designed for AI agents to quickly plan and execute small changes.",
+  schema: readQuickTasksSchema,
+  handler: async (params) => {
+    try {
+      if (params.id) {
+        // Fetch specific quick task by ID
+        const results = await db.select().from(quickTasks).where(eq(quickTasks.id, params.id));
+
+        if (results.length === 0) {
+          return {
+            content: [{
+              type: "text",
+              text: `No quick task found with ID: ${params.id}`,
+            }],
+          };
+        }
+
+        return {
+          content: [{
+            type: "text",
+            text: JSON.stringify(results[0], null, 2),
+          }],
+        };
+      }
+
+      // Build conditions
+      const conditions = [];
+      if (params.repoId) conditions.push(eq(quickTasks.repoId, params.repoId));
+      if (params.status) conditions.push(eq(quickTasks.status, params.status));
+
+      let query;
+      if (conditions.length > 0) {
+        query = db.select().from(quickTasks).where(and(...conditions));
+      } else {
+        query = db.select().from(quickTasks);
+      }
+
+      const results = await query;
+
+      return {
+        content: [{
+          type: "text",
+          text: JSON.stringify(results, null, 2),
+        }],
+      };
+    } catch (error) {
+      return {
+        content: [{
+          type: "text",
+          text: `Error reading quick tasks: ${error instanceof Error ? error.message : String(error)}`,
+        }],
+      };
+    }
+  },
+};

--- a/lib/mcp/tools/upsert-quick-task.ts
+++ b/lib/mcp/tools/upsert-quick-task.ts
@@ -1,0 +1,92 @@
+import { z } from "zod";
+import { eq } from "drizzle-orm";
+import { db, quickTasks } from "../../db/index.ts";
+import type { ToolDefinition } from "../types/tool.ts";
+
+const upsertQuickTaskSchema = z.object({
+  id: z.string().uuid().optional().describe("Quick task ID for update, omit for insert"),
+  repoId: z.string().uuid().describe("Repository ID this quick task belongs to"),
+  title: z.string().min(1).describe("Quick task title"),
+  description: z.string().optional().describe("Quick task description"),
+  status: z.enum(['planned', 'in_progress', 'completed', 'cancelled']).optional().describe("Quick task status"),
+  priority: z.enum(['low', 'medium', 'high', 'critical']).optional().describe("Quick task priority"),
+  orderIndex: z.number().int().optional().describe("Order within repository"),
+});
+
+export const upsertQuickTaskTool: ToolDefinition = {
+  name: "upsert_quick_task",
+  description: "Create a new quick task or update an existing one. Provide an ID to update, omit ID to create new. Quick tasks are lightweight tasks that belong directly to a repository and are designed for AI agents to quickly plan and execute small changes.",
+  schema: upsertQuickTaskSchema,
+  handler: async (params) => {
+    try {
+      if (params.id) {
+        // Update existing quick task
+        const updateData: Partial<typeof quickTasks.$inferInsert> = {
+          updatedAt: new Date(),
+        };
+
+        if (params.repoId !== undefined) updateData.repoId = params.repoId;
+        if (params.title !== undefined) updateData.title = params.title;
+        if (params.description !== undefined) updateData.description = params.description;
+        if (params.status !== undefined) {
+          updateData.status = params.status;
+          // Set completedAt when status changes to completed
+          if (params.status === 'completed') {
+            updateData.completedAt = new Date();
+          }
+        }
+        if (params.priority !== undefined) updateData.priority = params.priority;
+        if (params.orderIndex !== undefined) updateData.orderIndex = params.orderIndex;
+
+        const result = await db
+          .update(quickTasks)
+          .set(updateData)
+          .where(eq(quickTasks.id, params.id))
+          .returning();
+
+        if (result.length === 0) {
+          return {
+            content: [{
+              type: "text",
+              text: `No quick task found with ID: ${params.id}`,
+            }],
+          };
+        }
+
+        return {
+          content: [{
+            type: "text",
+            text: `Quick task updated successfully:\n${JSON.stringify(result[0], null, 2)}`,
+          }],
+        };
+      } else {
+        // Insert new quick task
+        const insertData: typeof quickTasks.$inferInsert = {
+          repoId: params.repoId,
+          title: params.title,
+        };
+
+        if (params.description !== undefined) insertData.description = params.description;
+        if (params.status !== undefined) insertData.status = params.status;
+        if (params.priority !== undefined) insertData.priority = params.priority;
+        if (params.orderIndex !== undefined) insertData.orderIndex = params.orderIndex;
+
+        const result = await db.insert(quickTasks).values(insertData).returning();
+
+        return {
+          content: [{
+            type: "text",
+            text: `Quick task created successfully:\n${JSON.stringify(result[0], null, 2)}`,
+          }],
+        };
+      }
+    } catch (error) {
+      return {
+        content: [{
+          type: "text",
+          text: `Error upserting quick task: ${error instanceof Error ? error.message : String(error)}`,
+        }],
+      };
+    }
+  },
+};


### PR DESCRIPTION
This commit introduces a new "quick tasks" feature that provides a lightweight alternative to the formal Epic → Story workflow. Quick tasks are designed for AI agents to quickly plan and execute small changes without the overhead of epic management.

Database changes:
- Add quick_tasks table with status enum (planned, in_progress, completed, cancelled)
- Modify planned_file_changes to support both storyId and quickTaskId (mutually exclusive)
- Add database migration (0005_add_quick_tasks.sql)

MCP Server changes:
- Add read_quick_tasks tool for fetching quick tasks with filters
- Add upsert_quick_task tool for creating/updating quick tasks
- Add delete_quick_task tool with cascade deletion
- Update read_planned_file_changes to support quickTaskId filter
- Update upsert_planned_file_change to accept quickTaskId as alternative to storyId

Web UI changes:
- Add Quick Tasks section to repository page
- Create QuickTaskCard component with status toggle and delete functionality
- Create CreateQuickTaskModal for quick task creation
- Add API endpoints for CRUD operations on quick tasks

Documentation:
- Update CLAUDE.md with quick tasks architecture and best practices
- Document dual workflow: formal (Epics → Stories) and quick (Quick Tasks)
- Add guidelines for when to use quick tasks vs stories