### PR TITLE
Add .env file to gitignore

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,9 @@
+# Database connection for Docker PostgreSQL (development)
+# Default credentials for local development only
+# Docker maps internal port 5432 to host port 5433
+DATABASE_URL=postgresql://postgres:postgres@localhost:5433/spec_this_development
+
+# Neo4j connection for file dependency graph
+NEO4J_URI=bolt://localhost:7687
+NEO4J_USERNAME=neo4j
+NEO4J_PASSWORD=your_neo4j_password_here

--- a/.gitignore
+++ b/.gitignore
@@ -32,7 +32,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
-!.env
+!.env.example
 
 # vercel
 .vercel


### PR DESCRIPTION
- Updated .gitignore to ignore all .env* files except .env.example
- Created .env.example template with placeholder values for DATABASE_URL and Neo4j config
- This prevents sensitive credentials from being committed to version control